### PR TITLE
Add command to validate codacy configuration file

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,6 +27,7 @@ lazy val codacyAnalysisCli = project
       Dependencies.jodaTime,
       Dependencies.codacyPlugins,
       Dependencies.fansi,
+      Dependencies.pprint,
       Dependencies.scalajHttp,
       Dependencies.cats) ++
       Dependencies.circe ++

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,6 +26,8 @@ object Dependencies {
 
   lazy val fansi = "com.lihaoyi" %% "fansi" % "0.2.5"
 
+  lazy val pprint = "com.lihaoyi" %% "pprint" % "0.5.3"
+
   lazy val scalajHttp = "org.scalaj" %% "scalaj-http" % "2.3.0"
 
   lazy val cats = "org.typelevel" %% "cats-core" % "1.1.0"

--- a/src/main/scala/com/codacy/analysis/cli/Main.scala
+++ b/src/main/scala/com/codacy/analysis/cli/Main.scala
@@ -7,7 +7,7 @@ import com.codacy.analysis.cli.clients.api.ProjectConfiguration
 import com.codacy.analysis.cli.clients.{CodacyClient, Credentials}
 import com.codacy.analysis.cli.command.analyse.AnalyseExecutor
 import com.codacy.analysis.cli.command.analyse.AnalyseExecutor.ExecutorResult
-import com.codacy.analysis.cli.command.{Analyse, CLIApp, Command}
+import com.codacy.analysis.cli.command._
 import com.codacy.analysis.cli.configuration.Environment
 import com.codacy.analysis.cli.files.FileCollector
 import com.codacy.analysis.cli.formatter.Formatter
@@ -26,7 +26,7 @@ class MainImpl extends CLIApp {
 
   private val logger: org.log4s.Logger = getLogger
 
-  def run(command: Command): Unit = {
+  def run(command: Command): ExitCode = {
     command match {
       case analyse: Analyse =>
         cleanup(analyse.directory)
@@ -67,12 +67,12 @@ class MainImpl extends CLIApp {
           }
         } else Right(())
 
-        exit(
-          new ExitStatus(analyse.maxAllowedIssues, analyse.failIfIncompleteValue)
-            .exitCode(analysisResults, uploadResult))
-    }
+        new ExitStatus(analyse.maxAllowedIssues, analyse.failIfIncompleteValue)
+          .exitCode(analysisResults, uploadResult)
 
-    ()
+      case validateConfiguration: ValidateConfiguration =>
+        new ValidateConfigurationExecutor(validateConfiguration).run()
+    }
   }
 
   private def uploadResults(codacyClientOpt: Option[CodacyClient])(

--- a/src/main/scala/com/codacy/analysis/cli/command/CLIApp.scala
+++ b/src/main/scala/com/codacy/analysis/cli/command/CLIApp.scala
@@ -10,9 +10,9 @@ import com.codacy.analysis.cli.formatter.Formatter
 import com.codacy.analysis.cli.tools.Tool
 
 abstract class CLIApp extends CommandAppWithBaseCommand[DefaultCommand, Command] {
-  def run(command: Command): Unit
+  def run(command: Command): ExitCode
 
-  override final def run(command: Command, remainingArgs: RemainingArgs): Unit = {
+  override final def run(command: Command, remainingArgs: RemainingArgs): ExitCode = {
     run(command)
   }
 
@@ -128,3 +128,10 @@ final case class Analyse(
   val failIfIncompleteValue: Boolean = failIfIncomplete.## > 0
   val allowNetworkValue: Boolean = allowNetwork.## > 0
 }
+
+final case class ValidateConfiguration(
+  @Recurse
+  options: CommonOptions,
+  @ExtraName("d") @ValueDescription("The directory where the configuration file is located")
+  directory: Option[File])
+    extends Command

--- a/src/main/scala/com/codacy/analysis/cli/command/CommandAppWithBaseCommand.scala
+++ b/src/main/scala/com/codacy/analysis/cli/command/CommandAppWithBaseCommand.scala
@@ -8,12 +8,13 @@ abstract class CommandAppWithBaseCommand[D, T](implicit
                                                baseBeforeCommandMessages: Messages[D],
                                                val commandParser: CommandParser[T],
                                                val commandsMessages: CommandsMessages[T]) {
+  type ExitCode = Int
 
   def defaultCommand(options: D, remainingArgs: Seq[String]): Unit
 
-  def run(options: T, remainingArgs: RemainingArgs): Unit
+  def run(options: T, remainingArgs: RemainingArgs): ExitCode
 
-  def exit(code: Int): Unit =
+  def exit(code: ExitCode): Unit =
     sys.exit(code)
 
   def error(message: String): Unit = {
@@ -98,7 +99,8 @@ abstract class CommandAppWithBaseCommand[D, T](implicit
               case Left(err) =>
                 error(err)
               case Right(t0) =>
-                run(t0, RemainingArgs(commandArgs, commandArgs0))
+                val code = run(t0, RemainingArgs(commandArgs, commandArgs0))
+                exit(code)
             }
         }
     }

--- a/src/main/scala/com/codacy/analysis/cli/command/ValidateConfigurationExecutor.scala
+++ b/src/main/scala/com/codacy/analysis/cli/command/ValidateConfigurationExecutor.scala
@@ -1,0 +1,25 @@
+package com.codacy.analysis.cli.command
+
+import better.files.File
+import com.codacy.analysis.cli.analysis.ExitStatus.ExitCodes
+import com.codacy.analysis.cli.configuration.CodacyConfigurationFile
+
+
+class ValidateConfigurationExecutor(validateConfiguration: ValidateConfiguration) {
+
+  def run(): CLIApp#ExitCode = {
+    val directory = validateConfiguration.directory.getOrElse(File.currentWorkingDirectory)
+
+    CodacyConfigurationFile.search(directory)
+      .flatMap(CodacyConfigurationFile.load) match {
+      case Left(e) =>
+        Console.err.println(e)
+        ExitCodes.failedAnalysis
+
+      case Right(configuration) =>
+        pprint.pprintln(configuration)
+        ExitCodes.success
+    }
+  }
+
+}


### PR DESCRIPTION
Add command to validate and print the codacy configuration file

Assumes that cli commands live in the `cli.command` package.
Changed the `def run(command: Command)` method to return an exit code.
Assumes that commands should be responsible for parsing their own configuration: `class ValidateConfigurationExecutor(validateConfiguration: ValidateConfiguration) `

