### PR TITLE
Use stable as default distribution version

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ docker run \
 * `--fail-if-incomplete` [default: false] - Fail the analysis if any tool fails to run
 * `--allow-network` [default: false] - Allow network access, so tools that need it can execute (e.g. findbugs)
 
+### Environment Variables
+
+* `CODACY_ANALYSIS_CLI_VERSION` - Set an alternative version of the CLI to run. (e.g. latest, 0.1.0-alpha3.1350, ...)
 
 ### Local configuration
 

--- a/bin/codacy-analysis-cli.sh
+++ b/bin/codacy-analysis-cli.sh
@@ -26,7 +26,7 @@ test_docker_socket() {
 }
 
 run() {
-  local CODACY_ANALYSIS_CLI_VERSION="${CODACY_ANALYSIS_CLI_VERSION:-latest}"
+  local CODACY_ANALYSIS_CLI_VERSION="${CODACY_ANALYSIS_CLI_VERSION:-stable}"
   docker run \
     --rm \
     --env CODACY_CODE="$CODACY_CODE" \


### PR DESCRIPTION
Depends on https://github.com/codacy/codacy-analysis-cli/pull/44