### PR TITLE
Adds inThisBuild to the resolvers 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import sbt._
 val scalaBinaryVersionNumber = "2.12"
 val scalaVersionNumber = s"$scalaBinaryVersionNumber.6"
 
-resolvers += Resolver.bintrayIvyRepo("sbt", "sbt-plugin-releases")
+resolvers in ThisBuild += Resolver.bintrayIvyRepo("sbt", "sbt-plugin-releases")
 
 lazy val aggregatedProjects: Seq[ProjectReference] = Seq(codacyAnalysisCore, codacyAnalysisCli)
 

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -12,7 +12,7 @@ object Common {
   private val dockerVersion = "docker-17.09.0-ce"
 
   val genericSettings: Seq[Def.Setting[_]] = Seq(
-    resolvers += "Codacy Public Mvn bucket" at "https://s3-eu-west-1.amazonaws.com/public.mvn.codacy.com",
+    resolvers in ThisBuild += "Codacy Public Mvn bucket" at "https://s3-eu-west-1.amazonaws.com/public.mvn.codacy.com",
     addCompilerPlugin("org.scalameta" % "semanticdb-scalac" % "4.0.0-M4" cross CrossVersion.full))
 
   val dockerSettings: Seq[Def.Setting[_]] = Seq(


### PR DESCRIPTION
the dependencies weren't being resolved since they were changed to the core subproject.