### PR TITLE
Adds set of analysed files to DuplicationAnalysis.Success

### DIFF
--- a/cli/src/main/scala/com/codacy/analysis/cli/Main.scala
+++ b/cli/src/main/scala/com/codacy/analysis/cli/Main.scala
@@ -119,8 +119,8 @@ class MainImpl extends CLIApp {
 
   def duplicationResults(duplicationExecutorToolResults: Seq[DuplicationToolExecutorResult]): Seq[DuplicationResult] = {
     duplicationExecutorToolResults.map {
-      case DuplicationToolExecutorResult(language, _, Success(duplicationClones)) =>
-        DuplicationResult(language, DuplicationAnalysis.Success(duplicationClones))
+      case DuplicationToolExecutorResult(language, files, Success(duplicationClones)) =>
+        DuplicationResult(language, DuplicationAnalysis.Success(files, duplicationClones))
       case DuplicationToolExecutorResult(language, _, Failure(err)) =>
         DuplicationResult(language, DuplicationAnalysis.Failure(err.getMessage))
     }

--- a/core/src/main/scala/com/codacy/analysis/core/model/ResultsSet.scala
+++ b/core/src/main/scala/com/codacy/analysis/core/model/ResultsSet.scala
@@ -38,6 +38,6 @@ final case class DuplicationResult(language: String, duplication: DuplicationAna
 sealed trait DuplicationAnalysis
 
 object DuplicationAnalysis {
-  final case class Success(results: Set[DuplicationClone]) extends DuplicationAnalysis
+  final case class Success(analysedFiles: Set[Path], results: Set[DuplicationClone]) extends DuplicationAnalysis
   final case class Failure(message: String) extends DuplicationAnalysis
 }

--- a/core/src/test/scala/com.codacy.analysis.core/upload/ResultsUploaderSpec.scala
+++ b/core/src/test/scala/com.codacy.analysis.core/upload/ResultsUploaderSpec.scala
@@ -152,7 +152,7 @@ class ResultsUploaderSpec extends Specification with NoLanguageFeatures with Moc
       val testDuplication = Seq(
         DuplicationResult(
           language,
-          DuplicationAnalysis.Success(Set(testClone(1), testClone(2)))))
+          DuplicationAnalysis.Success(Set.empty, Set(testClone(1), testClone(2)))))
 
       uploader.sendResults(Seq.empty, Seq.empty, testDuplication) must beRight.awaitFor(10.seconds)
 


### PR DESCRIPTION
It is needed to be able to check for missing files on the back end