### PR TITLE
feature: Depend on the new codacy-plugins

### DIFF
--- a/core/src/main/scala/com/codacy/analysis/core/tools/DuplicationTool.scala
+++ b/core/src/main/scala/com/codacy/analysis/core/tools/DuplicationTool.scala
@@ -27,7 +27,7 @@ class DuplicationTool(private val duplicationTool: traits.DuplicationTool, val l
 
     val request = DuplicationRequest(directory.pathAsString)
 
-    val dockerRunner = new BinaryDockerRunner[api.DuplicationClone](duplicationTool)
+    val dockerRunner = new BinaryDockerRunner[api.DuplicationClone](duplicationTool)()
     val runner = new DuplicationRunner(duplicationTool, dockerRunner)
 
     for {

--- a/core/src/main/scala/com/codacy/analysis/core/tools/MetricsTool.scala
+++ b/core/src/main/scala/com/codacy/analysis/core/tools/MetricsTool.scala
@@ -27,7 +27,7 @@ class MetricsTool(private val metricsTool: traits.MetricsTool, val languageToRun
           timeout: Option[Duration] = Option.empty[Duration]): Try[List[FileMetrics]] = {
     val request = MetricsRequest(directory.pathAsString)
 
-    val dockerRunner = new BinaryDockerRunner[api.metrics.FileMetrics](metricsTool)
+    val dockerRunner = new BinaryDockerRunner[api.metrics.FileMetrics](metricsTool)()
     val runner = new MetricsRunner(metricsTool, dockerRunner)
 
     val configuration = CodacyConfiguration(files, Some(languageToRun), None)

--- a/core/src/main/scala/com/codacy/analysis/core/tools/Tool.scala
+++ b/core/src/main/scala/com/codacy/analysis/core/tools/Tool.scala
@@ -132,7 +132,7 @@ object Tool {
   val allToolShortNames: Set[String] = internetToolShortNames ++ availableTools.map(_.shortName)
 
   def apply(plugin: DockerTool, languageToRun: Language): Tool = {
-    val dockerRunner = new BinaryDockerRunner[Result](plugin)
+    val dockerRunner = new BinaryDockerRunner[Result](plugin)()
     val runner = new ToolRunner(plugin, new DockerToolDocumentation(plugin), dockerRunner)
     new Tool(runner, DockerRunner.defaultRunTimeout)(plugin, languageToRun)
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,7 +24,7 @@ object Dependencies {
 
   lazy val caseApp = "com.github.alexarchambault" %% "case-app" % "1.2.0"
 
-  lazy val codacyPlugins = Seq("codacy" %% "codacy-plugins" % "5.0.346")
+  lazy val codacyPlugins = Seq("codacy" %% "codacy-plugins" % "5.0.407")
 
   lazy val fansi = "com.lihaoyi" %% "fansi" % "0.2.5"
 


### PR DESCRIPTION
It now reads codacy.tests.noremove as a property to keep the containers for debug