### PR TITLE
Replace tokens underscore with hyphen: CY-1262

### DIFF
--- a/core/src/main/scala/com/codacy/analysis/core/clients/CodacyClient.scala
+++ b/core/src/main/scala/com/codacy/analysis/core/clients/CodacyClient.scala
@@ -194,10 +194,16 @@ object CodacyClient {
   def apply(credentials: Credentials)(implicit context: ExecutionContext): CodacyClient = {
     credentials match {
       case ProjectToken(token, baseUrl) =>
-        val headers: Map[String, String] = Map(("project_token", token))
+        val headers: Map[String, String] = Map(
+          ("project-token", token),
+          // This is deprecated and is kept for backward compatibility. It will removed in the context of CY-1272
+          ("project_token", token))
         new CodacyClient(credentials, new HttpHelper(baseUrl, headers))
       case APIToken(token, baseUrl, _, _) =>
-        val headers: Map[String, String] = Map(("api_token", token))
+        val headers: Map[String, String] = Map(
+          ("api-token", token),
+          // This is deprecated and is kept for backward compatibility. It will removed in the context of CY-1272
+          ("api_token", token))
         new CodacyClient(credentials, new HttpHelper(baseUrl, headers))
     }
   }


### PR DESCRIPTION
The problem is nginx, used in k8s, by default drops all http request headers that contain the underscore char, meaning that project_token and api_token headers are not reaching the route handlers and these are failing on the authentication step.

Therefore we are changing the API tokens to use "-" instead of "_".

More context in bitbucket.org/qamine/codacy-website/pull-requests/3185