### PR TITLE
docs: update name of api tokens tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ codacy-analysis-cli analyse \
 #### API Token
 
 You can find the project token in:
-* `Account -> API Tokens`
+* `Account -> Access Management`
 
 The username and project name can be retrieved from the URL in Codacy.
 


### PR DESCRIPTION
The location of api tokens is now in a tab called Access Management