### PR TITLE
test: Add slack notification to integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   codacy: codacy/base@2.14.8
+  slack: circleci/slack@3.3.0
 
 references:
   restore_maven_dependencies: &restore_maven_dependencies
@@ -73,6 +74,11 @@ references:
           path: ~/junit
       - store_artifacts:
           path: ExtentReports/
+      - slack/status:
+          fail_only: false
+          only_for_branches: "master"
+          webhook: https://hooks.slack.com/services/$SLACK_TOKEN
+          failure_message: ":red_circle: A $CIRCLE_JOB job has failed! See more on: $RP_LAUNCH_URL, login with the default user."
 
 jobs:
   maven_dependencies:
@@ -109,6 +115,7 @@ jobs:
       PROJECT_NAME: codacy-analysis-cli
       LAUNCH_NAME: CLI_STAGING
       RP_LAUNCH_URL: https://reportportal.staging.codacy.org/ui/#codacy-analysis-cli/launches
+      SLACK_TOKEN: $SLACK_TOKEN_STAGING
   test_production:
     <<: *run_integration_tests
     environment:
@@ -118,6 +125,7 @@ jobs:
       PROJECT_NAME: codacy-analysis-cli
       LAUNCH_NAME: CLI_PROD
       RP_LAUNCH_URL: https://reportportal.staging.codacy.org/ui/#codacy-analysis-cli/launches
+      SLACK_TOKEN: $SLACK_TOKEN_PROD
 
 workflows:
   version: 2


### PR DESCRIPTION
We missed a lot of tests failing and with this change we hope it's easier to find failing workflows