### PR TITLE
docs: Add absolute path requirement to directory param CY-2997

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Found [Clone] 7 duplicated lines with 10 tokens:
 * `analyse` - Run a Codacy analysis over a directory/files
     * `--verbose` - Run the tool with verbose output
     * `--tool` - Choose the tool to analyse the code (e.g. brakeman)
-    * `--directory` - Choose the directory to be analysed
+    * `--directory` - Absolute path to the directory to be analysed
     * `--codacy-api-base-url` or env.`CODACY_API_BASE_URL` - Change the Codacy installation API URL to retrieve the configuration (e.g. Enterprise installation)
     * `--output` - Send the output results to a file
     * `--format` [default: text] - Change the output format (e.g. json)


### PR DESCRIPTION
This originated from #314
We hope that having this requirement clear in the documentation avoids future errors