### PR TITLE
breaking: Change spelling of the `analyse` command to `analyze` [CY-2939]

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ cd codacy-analysis-cli-* && sudo make install
 ### Script
 
 ```sh
-codacy-analysis-cli analyse \
+codacy-analysis-cli analyze \
   --tool <TOOL-SHORT-NAME> \
   --directory <SOURCE-CODE-PATH>
 ```
@@ -113,7 +113,7 @@ codacy-analysis-cli analyse \
 ### Java
 
 ```
-java -jar codacy-analysis-cli-assembly-{VERSION}.jar analyse \
+java -jar codacy-analysis-cli-assembly-{VERSION}.jar analyze \
   --tool <TOOL-SHORT-NAME> \
   --directory <SOURCE-CODE-PATH> \
   # other options
@@ -122,7 +122,7 @@ java -jar codacy-analysis-cli-assembly-{VERSION}.jar analyse \
 ### Local
 
 ```sh
-sbt "codacyAnalysisCli/runMain com.codacy.analysis.cli.Main analyse --tool <TOOL-SHORT-NAME> --directory <SOURCE-CODE-PATH>"
+sbt "codacyAnalysisCli/runMain com.codacy.analysis.cli.Main analyze --tool <TOOL-SHORT-NAME> --directory <SOURCE-CODE-PATH>"
 ```
 
 ### Docker
@@ -135,7 +135,7 @@ docker run \
   --volume "$CODACY_CODE":"$CODACY_CODE" \
   --volume /tmp:/tmp \
   codacy/codacy-analysis-cli \
-    analyse --tool <TOOL-SHORT-NAME>
+    analyze --tool <TOOL-SHORT-NAME>
 ```
 
 
@@ -202,10 +202,10 @@ Found [Clone] 7 duplicated lines with 10 tokens:
 
 ### Commands and Configuration
 
-* `analyse` - Run a Codacy analysis over a directory/files
+* `analyze` - Run a Codacy analysis over a directory/files
     * `--help` - Displays all the configuration options, their meaning and possible values.
     * `--verbose` - Run the tool with verbose output
-    * `--tool` - Choose the tool to analyse the code (e.g. brakeman)
+    * `--tool` - Choose the tool to analyze the code (e.g. brakeman)
     * `--directory` - Choose the directory to be analysed
     * `--codacy-api-base-url` or env.`CODACY_API_BASE_URL` - Change the Codacy installation API URL to retrieve the configuration (e.g. Enterprise installation)
     * `--output` - Send the output results to a file
@@ -244,7 +244,7 @@ You can find the project token in:
 * `Project -> Settings -> Integrations -> Add Integration -> Project API`
 
 ```sh
-codacy-analysis-cli analyse \
+codacy-analysis-cli analyze \
   --project-token <PROJECT-TOKEN> \
   --tool <TOOL-SHORT-NAME> \
   --directory <SOURCE-CODE-PATH>
@@ -260,7 +260,7 @@ You can find the project token in:
 The username and project name can be retrieved from the URL in Codacy.
 
 ```sh
-codacy-analysis-cli analyse \
+codacy-analysis-cli analyze \
   --api-token <PROJECT-TOKEN> \
   --username <USERNAME> \
   --project <PROJECT-NAME> \
@@ -339,6 +339,11 @@ sbt codacyCoverage
 
         sbt 'set version in codacyAnalysisCore := "<VERSION>"' 'set pgpPassphrase := Some("<SONATYPE_GPG_PASSPHRASE>".toCharArray)' codacyAnalysisCore/publishSigned
         sbt 'set version in codacyAnalysisCore := "<VERSION>"' sonatypeRelease
+
+## Breaking Changes
+
+- 4.0.0 - Rename `analyse` command to `analyze`. This is a breaking change if you are running the CLI by using the
+  [jar](#java) or [`sbt`](#local), but not if you are using the [provided script](#script).
 
 ## What is Codacy
 

--- a/bin/codacy-analysis-cli.sh
+++ b/bin/codacy-analysis-cli.sh
@@ -60,7 +60,7 @@ analysis_file() {
       *)
         if [ ${is_filename} -eq 1 ]; then
           if [ -n "$filename" ]; then
-            echo "Please provide only one file or directory to analyse" >&2
+            echo "Please provide only one file or directory to analyze" >&2
             exit 1
           else
             is_filename=0
@@ -104,7 +104,11 @@ prep_args_with_output_absolute_path() {
             new_args="${new_args} ${OUTPUT}"
           fi
         else
-          new_args="${new_args} ${arg}"
+          if [ ${arg} == "analyse" ]; then
+            new_args="${new_args} analyze"
+          else
+            new_args="${new_args} ${arg}"
+          fi
         fi
         ;;
     esac

--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ lazy val codacyAnalysisCore = project
     // Test Dependencies
     libraryDependencies ++= Dependencies.specs2,
     sonatypeInformation,
-    description := "Library to analyse projects")
+    description := "Library to analyze projects")
   .settings(assemblyCommon: _*)
   // Disable legacy Scalafmt plugin imported by codacy-sbt-plugin
   .disablePlugins(com.lucidchart.sbt.scalafmt.ScalafmtCorePlugin)

--- a/cli/src/main/scala/com/codacy/analysis/cli/Main.scala
+++ b/cli/src/main/scala/com/codacy/analysis/cli/Main.scala
@@ -5,7 +5,7 @@ import com.codacy.analysis.cli.command.{AnalyseCommand, CLIApp, _}
 
 object Main extends MainImpl()
 
-class MainImpl(analyseCommand: Analyse => AnalyseCommand = AnalyseCommand(_, sys.env),
+class MainImpl(analyseCommand: Analyze => AnalyseCommand = AnalyseCommand(_, sys.env),
                validateConfigurationCommand: ValidateConfiguration => ValidateConfigurationCommand =
                  ValidateConfigurationCommand(_))
     extends CLIApp {
@@ -16,7 +16,7 @@ class MainImpl(analyseCommand: Analyse => AnalyseCommand = AnalyseCommand(_, sys
 
   def runCommand(command: CommandOptions): ExitStatus.ExitCode = {
     command match {
-      case analyse: Analyse => analyseCommand(analyse).run()
+      case analyze: Analyze => analyseCommand(analyze).run()
       case validateConfiguration: ValidateConfiguration =>
         validateConfigurationCommand(validateConfiguration).run()
     }

--- a/cli/src/main/scala/com/codacy/analysis/cli/command/CLIApp.scala
+++ b/cli/src/main/scala/com/codacy/analysis/cli/command/CLIApp.scala
@@ -120,14 +120,14 @@ final case class ExtraOptions(
   @Hidden @ValueDescription(s"The analyser to use. (${Analyser.allAnalysers.map(_.name).mkString(", ")})")
   analyser: String = Analyser.defaultAnalyser.name)
 
-final case class Analyse(
+final case class Analyze(
   @Recurse
   options: CommonOptions,
   @Recurse
   api: APIOptions,
-  @ExtraName("t") @ValueDescription(s"The tool to analyse the code. (${Tool.allToolShortNames.mkString(", ")})")
+  @ExtraName("t") @ValueDescription(s"The tool to analyze the code. (${Tool.allToolShortNames.mkString(", ")})")
   tool: Option[String],
-  @ExtraName("d") @ValueDescription("The directory to analyse.")
+  @ExtraName("d") @ValueDescription("The directory to analyze.")
   directory: Option[File],
   @ExtraName("f") @ValueDescription(s"The output format. (${Formatter.allFormatters.map(_.name).mkString(", ")})")
   format: String = Formatter.defaultFormatter.name,

--- a/cli/src/main/scala/com/codacy/analysis/cli/configuration/CLIConfiguration.scala
+++ b/cli/src/main/scala/com/codacy/analysis/cli/configuration/CLIConfiguration.scala
@@ -3,7 +3,7 @@ package com.codacy.analysis.cli.configuration
 import better.files.File
 import cats.Foldable
 import cats.implicits._
-import com.codacy.analysis.cli.command.Analyse
+import com.codacy.analysis.cli.command.Analyze
 import com.codacy.analysis.core.clients.CodacyClient
 import com.codacy.analysis.core.clients.api._
 import com.codacy.analysis.core.configuration.{
@@ -41,22 +41,22 @@ object CLIConfiguration {
   object Analysis {
 
     def apply(projectDirectory: File,
-              analyse: Analyse,
+              analyze: Analyze,
               localConfiguration: Either[String, CodacyConfigurationFile],
               remoteProjectConfiguration: Either[String, ProjectConfiguration],
               tmpDirectory: Option[File]): Analysis = {
 
       val fileExclusionRules =
         CLIConfiguration.FileExclusionRules(localConfiguration, remoteProjectConfiguration)
-      val output = CLIConfiguration.Output(analyse.format, analyse.output, analyse.ghCodeScanningCompatValue)
+      val output = CLIConfiguration.Output(analyze.format, analyze.output, analyze.ghCodeScanningCompatValue)
       val toolConfiguration =
-        CLIConfiguration.Tool(analyse, localConfiguration, remoteProjectConfiguration)
+        CLIConfiguration.Tool(analyze, localConfiguration, remoteProjectConfiguration)
       CLIConfiguration.Analysis(
         projectDirectory,
         output,
-        analyse.tool,
-        analyse.parallel,
-        analyse.forceFilePermissionsValue,
+        analyze.tool,
+        analyze.parallel,
+        analyze.forceFilePermissionsValue,
         fileExclusionRules,
         toolConfiguration,
         tmpDirectory)
@@ -124,7 +124,7 @@ object CLIConfiguration {
 
   object Tool {
 
-    def apply(analyse: Analyse,
+    def apply(analyze: Analyze,
               localConfiguration: Either[String, CodacyConfigurationFile],
               remoteProjectConfiguration: Either[String, ProjectConfiguration]): CLIConfiguration.Tool = {
 
@@ -141,8 +141,8 @@ object CLIConfiguration {
         localConfiguration.map(_.languageCustomExtensions).getOrElse(Map.empty[Language, Set[String]])
 
       CLIConfiguration.Tool(
-        analyse.toolTimeout,
-        analyse.allowNetworkValue,
+        analyze.toolTimeout,
+        analyze.allowNetworkValue,
         toolConfigurations,
         enginesConfiguration,
         languageExtensions)
@@ -191,11 +191,11 @@ object CLIConfiguration {
 
   def apply(clientOpt: Option[CodacyClient],
             environment: Environment,
-            analyse: Analyse,
+            analyze: Analyze,
             localConfigLoader: CodacyConfigurationFileLoader): CLIConfiguration = {
-    val projectDirectory: File = environment.baseProjectDirectory(analyse.directory)
+    val projectDirectory: File = environment.baseProjectDirectory(analyze.directory)
     val commitUuid: Option[Commit.Uuid] =
-      analyse.commitUuid.orElse(Git.currentCommitUuid(projectDirectory))
+      analyze.commitUuid.orElse(Git.currentCommitUuid(projectDirectory))
 
     val localConfiguration: Either[String, CodacyConfigurationFile] =
       localConfigLoader.load(projectDirectory)
@@ -205,9 +205,9 @@ object CLIConfiguration {
       _.getRemoteConfiguration
     }
     val analysisConfiguration =
-      Analysis(projectDirectory, analyse, localConfiguration, remoteProjectConfiguration, analyse.tmpDirectory)
-    val uploadConfiguration = Upload(commitUuid, analyse.uploadValue)
-    val resultConfiguration = Result(analyse.maxAllowedIssues, analyse.failIfIncompleteValue)
+      Analysis(projectDirectory, analyze, localConfiguration, remoteProjectConfiguration, analyze.tmpDirectory)
+    val uploadConfiguration = Upload(commitUuid, analyze.uploadValue)
+    val resultConfiguration = Result(analyze.maxAllowedIssues, analyze.failIfIncompleteValue)
 
     CLIConfiguration(analysisConfiguration, uploadConfiguration, resultConfiguration)
   }

--- a/cli/src/test/scala/com/codacy/analysis/cli/AnalyseExecutorSpec.scala
+++ b/cli/src/test/scala/com/codacy/analysis/cli/AnalyseExecutorSpec.scala
@@ -26,7 +26,7 @@ class AnalyseExecutorSpec extends Specification with NoLanguageFeatures with Moc
     val pyLintPatternsInternalIds = Set("PyLint_C0111", "PyLint_E1101")
     val pathToIgnore = "lib/improver/tests/"
 
-    s"""|analyse a python project with pylint, using a remote project configuration retrieved with a project token
+    s"""|analyze a python project with pylint, using a remote project configuration retrieved with a project token
         | that ignores the files that start with the path $pathToIgnore
         | and considers just patterns ${pyLintPatternsInternalIds.mkString(", ")}""".stripMargin in {
       val commitUuid = "9232dbdcae98b19412c8dd98c49da8c391612bfa"
@@ -75,7 +75,7 @@ class AnalyseExecutorSpec extends Specification with NoLanguageFeatures with Moc
     val esLintPatternsInternalIds =
       Set("ESLint_semi", "ESLint_no-undef", "ESLint_indent", "ESLint_no-empty")
 
-    s"""|analyse a javascript project with eslint, using a remote project configuration retrieved with an api token
+    s"""|analyze a javascript project with eslint, using a remote project configuration retrieved with an api token
         | that considers just patterns ${esLintPatternsInternalIds.mkString(", ")}""".stripMargin in {
       val commitUuid = "9232dbdcae98b19412c8dd98c49da8c391612bfa"
       withClonedRepo("git://github.com/qamine-test/Monogatari.git", commitUuid) { (file, directory) =>
@@ -116,7 +116,7 @@ class AnalyseExecutorSpec extends Specification with NoLanguageFeatures with Moc
 
     val cssLintPatternsInternalIds = Set("CSSLint_important")
 
-    "analyse a javascript and css project" in {
+    "analyze a javascript and css project" in {
       val commitUuid = "9232dbdcae98b19412c8dd98c49da8c391612bfa"
       withClonedRepo("git://github.com/qamine-test/Monogatari.git", commitUuid) { (file, directory) =>
         val configuration = analysisConfiguration(

--- a/cli/src/test/scala/com/codacy/analysis/cli/CLISpec.scala
+++ b/cli/src/test/scala/com/codacy/analysis/cli/CLISpec.scala
@@ -32,21 +32,21 @@ class CLISpec extends Specification with NoLanguageFeatures with FileMatchers {
       cli.parse(Array("--version")) must beLike {
         case Right((DefaultCommand(_), _, parsed)) => parsed must beNone
       }
-      cli.parse(Array("analyse", "--directory", "/tmp", "--tool", "pylint")) must beLike {
+      cli.parse(Array("analyze", "--directory", "/tmp", "--tool", "pylint")) must beLike {
         case Right((DefaultCommand(_), _, Some(parsed))) => parsed must beRight
       }
-      cli.parse(Array("analyse", "--directory", "/tmp", "--tool", "pylint", "--output", "/tmp/test.txt")) must beLike {
+      cli.parse(Array("analyze", "--directory", "/tmp", "--tool", "pylint", "--output", "/tmp/test.txt")) must beLike {
         case Right((DefaultCommand(_), _, Some(parsed))) => parsed must beRight
       }
-      cli.parse(Array("analyse", "--directory", "/tmp", "--tool", "pylint", "--verbose")) must beLike {
+      cli.parse(Array("analyze", "--directory", "/tmp", "--tool", "pylint", "--verbose")) must beLike {
         case Right((DefaultCommand(_), _, Some(parsed))) => parsed must beRight
       }
-      cli.parse(Array("analyse", "--directory", "/tmp", "--tool", "pylint", "--format", "json")) must beLike {
+      cli.parse(Array("analyze", "--directory", "/tmp", "--tool", "pylint", "--format", "json")) must beLike {
         case Right((DefaultCommand(_), _, Some(parsed))) => parsed must beRight
       }
       cli.parse(
         Array(
-          "analyse",
+          "analyze",
           "--directory",
           "/tmp",
           "--tool",
@@ -60,13 +60,13 @@ class CLISpec extends Specification with NoLanguageFeatures with FileMatchers {
     "fail parse" in {
       cli.parse(Array("bad-command", "--directory", "/tmp", "--tool", "pylint")) must beEqualTo(
         Right(errorMsg("Command not found: bad-command")))
-      cli.parse(Array("analyse", "--bad-parameter", "/tmp", "--tool", "pylint")) must beEqualTo(
+      cli.parse(Array("analyze", "--bad-parameter", "/tmp", "--tool", "pylint")) must beEqualTo(
         Right(errorMsg("Unrecognized argument: --bad-parameter")))
-      cli.parse(Array("analyse", "analyse", "--tool-timeout", "1semilha")) must beEqualTo(
+      cli.parse(Array("analyze", "analyze", "--tool-timeout", "1semilha")) must beEqualTo(
         Right(errorMsg("Invalid duration 1semilha (e.g. 20minutes, 10seconds, ...)")))
       cli.parse(
         Array(
-          "analyse",
+          "analyze",
           "--directory",
           "/tmp",
           "--tool",
@@ -84,7 +84,7 @@ class CLISpec extends Specification with NoLanguageFeatures with FileMatchers {
         file <- File.temporaryFile()
       } yield {
         cli.main(
-          Array("analyse", "--directory", directory.pathAsString, "--tool", "pylint", "--output", file.pathAsString))
+          Array("analyze", "--directory", directory.pathAsString, "--tool", "pylint", "--output", file.pathAsString))
 
         file.contentAsString must beEqualTo("""|Starting analysis ...
                                                |Analysis complete
@@ -99,7 +99,7 @@ class CLISpec extends Specification with NoLanguageFeatures with FileMatchers {
       } yield {
         cli.main(
           Array(
-            "analyse",
+            "analyze",
             "--directory",
             directory.pathAsString,
             "--tool",
@@ -119,7 +119,7 @@ class CLISpec extends Specification with NoLanguageFeatures with FileMatchers {
         (file, directory) =>
           cli.main(
             Array(
-              "analyse",
+              "analyze",
               "--directory",
               directory./("src/main/resources/docs/directory-tests/rails4").pathAsString,
               "--tool",
@@ -150,7 +150,7 @@ class CLISpec extends Specification with NoLanguageFeatures with FileMatchers {
         "38e5ab22774c6061ce693efab4011d49b8feb5ca") { (file, directory) =>
         cli.main(
           Array(
-            "analyse",
+            "analyze",
             "--directory",
             directory.pathAsString,
             "--tool",
@@ -177,7 +177,7 @@ class CLISpec extends Specification with NoLanguageFeatures with FileMatchers {
         (file, directory) =>
           cli.main(
             Array(
-              "analyse",
+              "analyze",
               "--directory",
               directory.pathAsString,
               "--tool",
@@ -208,7 +208,7 @@ class CLISpec extends Specification with NoLanguageFeatures with FileMatchers {
         (file, directory) =>
           cli.main(
             Array(
-              "analyse",
+              "analyze",
               "--directory",
               directory.pathAsString,
               "--tool",
@@ -240,7 +240,7 @@ class CLISpec extends Specification with NoLanguageFeatures with FileMatchers {
         (file, directory) =>
           cli.main(
             Array(
-              "analyse",
+              "analyze",
               "--directory",
               directory.pathAsString,
               "--tool",
@@ -274,7 +274,7 @@ class CLISpec extends Specification with NoLanguageFeatures with FileMatchers {
 
           CommandRunner.exec(List("git", "add", newFile.name), Option(directory.toJava))
 
-          val analyse = Analyse(
+          val analyze = Analyze(
             options = CommonOptions(),
             api = APIOptions(projectToken = None, codacyApiBaseUrl = None),
             tool = None,
@@ -283,7 +283,7 @@ class CLISpec extends Specification with NoLanguageFeatures with FileMatchers {
             extras = ExtraOptions(),
             toolTimeout = None)
 
-          cli.run(analyse) must beEqualTo(ExitStatus.ExitCodes.uncommittedChanges)
+          cli.run(analyze) must beEqualTo(ExitStatus.ExitCodes.uncommittedChanges)
         }).get
       }
     }
@@ -293,7 +293,7 @@ class CLISpec extends Specification with NoLanguageFeatures with FileMatchers {
         (for {
           _ <- File.temporaryFile(parent = Some(directory))
         } yield {
-          val analyse = Analyse(
+          val analyze = Analyze(
             options = CommonOptions(),
             api = APIOptions(projectToken = None, codacyApiBaseUrl = None),
             tool = None,
@@ -301,7 +301,7 @@ class CLISpec extends Specification with NoLanguageFeatures with FileMatchers {
             upload = Tag.of(1),
             extras = ExtraOptions(),
             toolTimeout = None)
-          cli.run(analyse) must beEqualTo(ExitStatus.ExitCodes.uncommittedChanges)
+          cli.run(analyze) must beEqualTo(ExitStatus.ExitCodes.uncommittedChanges)
         }).get
       }
     }
@@ -314,7 +314,7 @@ class CLISpec extends Specification with NoLanguageFeatures with FileMatchers {
 
           CommandRunner.exec(List("git", "add", newFile.name), Option(directory.toJava))
 
-          val analyse = Analyse(
+          val analyze = Analyze(
             options = CommonOptions(),
             api = APIOptions(projectToken = Some("hey, im a token"), codacyApiBaseUrl = Some("https://codacy.com")),
             tool = None,
@@ -323,7 +323,7 @@ class CLISpec extends Specification with NoLanguageFeatures with FileMatchers {
             extras = ExtraOptions(),
             toolTimeout = None)
 
-          cli.run(analyse) must beEqualTo(ExitStatus.ExitCodes.failedAnalysis)
+          cli.run(analyze) must beEqualTo(ExitStatus.ExitCodes.failedAnalysis)
         }).get
       }
     }
@@ -333,7 +333,7 @@ class CLISpec extends Specification with NoLanguageFeatures with FileMatchers {
         (for {
           _ <- File.temporaryFile(parent = Some(directory))
         } yield {
-          val analyse = Analyse(
+          val analyze = Analyze(
             options = CommonOptions(),
             api = APIOptions(projectToken = Some("hey, im a token"), codacyApiBaseUrl = Some("https://codacy.com")),
             tool = None,
@@ -342,7 +342,7 @@ class CLISpec extends Specification with NoLanguageFeatures with FileMatchers {
             extras = ExtraOptions(),
             commitUuid = Option(Commit.Uuid("Aw geez Rick, this isnt the commit uuid!")),
             toolTimeout = None)
-          cli.run(analyse) must beEqualTo(ExitStatus.ExitCodes.commitsDoNotMatch)
+          cli.run(analyze) must beEqualTo(ExitStatus.ExitCodes.commitsDoNotMatch)
         }).get
       }
     }
@@ -351,7 +351,7 @@ class CLISpec extends Specification with NoLanguageFeatures with FileMatchers {
       (for {
         directory <- File.temporaryDirectory()
       } yield {
-        cli.main(Array("analyse", "--directory", directory.pathAsString, "--tool", "pylint"))
+        cli.main(Array("analyze", "--directory", directory.pathAsString, "--tool", "pylint"))
 
         (directory / ".codacy.json").toJava must not(exist)
         (directory / ".codacyrc").toJava must not(exist)

--- a/cli/src/test/scala/com/codacy/analysis/cli/configuration/CLIConfigurationSpec.scala
+++ b/cli/src/test/scala/com/codacy/analysis/cli/configuration/CLIConfigurationSpec.scala
@@ -2,7 +2,7 @@ package com.codacy.analysis.cli.configuration
 
 import better.files.File
 import caseapp.Tag
-import com.codacy.analysis.cli.command.{APIOptions, Analyse, CommonOptions, ExtraOptions}
+import com.codacy.analysis.cli.command.{APIOptions, Analyze, CommonOptions, ExtraOptions}
 import com.codacy.analysis.cli.formatter.Json
 import com.codacy.analysis.core.analysis.Analyser
 import com.codacy.analysis.core.clients._
@@ -40,7 +40,7 @@ class CLIConfigurationSpec extends Specification with NoLanguageFeatures {
   private val toolInput = Option("hey! i'm a tool!")
   private val commitUuid = Option(Commit.Uuid("uuid"))
 
-  private val defaultAnalyse = Analyse(
+  private val defaultAnalyse = Analyze(
     options = CommonOptions(),
     api = APIOptions(),
     tool = toolInput,
@@ -62,13 +62,13 @@ class CLIConfigurationSpec extends Specification with NoLanguageFeatures {
 
   "CLIConfiguration" should {
 
-    "parse configuration from analyse command" in {
+    "parse configuration from analyze command" in {
 
       (for {
         directory <- File.temporaryDirectory()
         outputFile <- File.temporaryFile()
       } yield {
-        val analyse = Analyse(
+        val analyze = Analyze(
           options = CommonOptions(),
           api = APIOptions(),
           tool = toolInput,
@@ -107,7 +107,7 @@ class CLIConfigurationSpec extends Specification with NoLanguageFeatures {
           result = CLIConfiguration.Result(maxAllowedIssues = 5, failIfIncomplete = true))
 
         val actualConfiguration =
-          CLIConfiguration(Option(noRemoteConfigCodacyClient), defaultEnvironment, analyse, noLocalConfig)
+          CLIConfiguration(Option(noRemoteConfigCodacyClient), defaultEnvironment, analyze, noLocalConfig)
 
         actualConfiguration must beEqualTo(expectedConfiguration)
       }).get
@@ -226,7 +226,7 @@ class CLIConfigurationSpec extends Specification with NoLanguageFeatures {
 
     }
 
-    "parse configuration with environment and analyse command values (no remote or local configs)" in {
+    "parse configuration with environment and analyze command values (no remote or local configs)" in {
 
       val environment = new Environment(Map("CODACY_CODE" -> "."))
 

--- a/core/src/main/scala/com/codacy/analysis/core/tools/Tool.scala
+++ b/core/src/main/scala/com/codacy/analysis/core/tools/Tool.scala
@@ -91,7 +91,7 @@ class Tool(runner: ToolRunner, defaultRunTimeout: Duration)(private val plugin: 
             fe =>
               FileError(
                 FileHelper.relativePath(sourceDirectory.appendPrefix(fe.filename)),
-                fe.message.getOrElse("Failed to analyse file.")))
+                fe.message.getOrElse("Failed to analyze file.")))
     }
   }
 

--- a/core/src/test/scala/com.codacy.analysis.core/tools/DuplicationToolSpec.scala
+++ b/core/src/test/scala/com.codacy.analysis.core/tools/DuplicationToolSpec.scala
@@ -15,7 +15,7 @@ import scala.util.Success
 class DuplicationToolSpec extends Specification with NoLanguageFeatures {
 
   "DuplicationTool" should {
-    "analyse duplication on a project" in {
+    "analyze duplication on a project" in {
       val commitUuid = "625e19cd9be4898939a7c40dbeb2b17e40df9d54"
       withClonedRepo("git://github.com/qamine-test/duplication-delta.git", commitUuid) { (_, directory) =>
         val expectedClones = Seq(
@@ -45,7 +45,7 @@ class DuplicationToolSpec extends Specification with NoLanguageFeatures {
       }
     }
 
-    "analyse duplication on a project, ignoring a file" in {
+    "analyze duplication on a project, ignoring a file" in {
       val commitUuid = "625e19cd9be4898939a7c40dbeb2b17e40df9d54"
       withClonedRepo("git://github.com/qamine-test/duplication-delta.git", commitUuid) { (_, directory) =>
         val expectedClones = Seq(

--- a/core/src/test/scala/com.codacy.analysis.core/tools/MetricsToolSpec.scala
+++ b/core/src/test/scala/com.codacy.analysis.core/tools/MetricsToolSpec.scala
@@ -19,7 +19,7 @@ class MetricsToolSpec extends Specification with NoLanguageFeatures {
   val jsTestMetrics = FileMetrics(Paths.get("test.js"), None, Some(60), Some(0), None, None, Set())
 
   "MetricsTool" should {
-    "analyse metrics on a project" in {
+    "analyze metrics on a project" in {
       val commitUuid = "625e19cd9be4898939a7c40dbeb2b17e40df9d54"
       withClonedRepo("git://github.com/qamine-test/duplication-delta.git", commitUuid) { (_, directory) =>
         val testProjectFileMetrics = List(jsTest2Metrics, jsTestMetrics)
@@ -37,7 +37,7 @@ class MetricsToolSpec extends Specification with NoLanguageFeatures {
       }
     }
 
-    "analyse metrics on a project, ignoring a file" in {
+    "analyze metrics on a project, ignoring a file" in {
       val commitUuid = "625e19cd9be4898939a7c40dbeb2b17e40df9d54"
       withClonedRepo("git://github.com/qamine-test/duplication-delta.git", commitUuid) { (_, directory) =>
         val testProjectFileMetrics = List(jsTestMetrics)

--- a/core/src/test/scala/com.codacy.analysis.core/upload/ResultsUploaderSpec.scala
+++ b/core/src/test/scala/com.codacy.analysis.core/upload/ResultsUploaderSpec.scala
@@ -178,7 +178,7 @@ class ResultsUploaderSpec extends Specification with NoLanguageFeatures with Moc
     val esLintPatternsInternalIds =
       Set("ESLint_semi", "ESLint_no-undef", "ESLint_indent", "ESLint_no-empty")
 
-    s"analyse a javascript project with eslint, $message".stripMargin in {
+    s"analyze a javascript project with eslint, $message".stripMargin in {
       val toolPatterns = esLintPatternsInternalIds.map { patternId =>
         ToolPattern(patternId, Set.empty)
       }


### PR DESCRIPTION
This change guarantees retro-compatibility with the `analyse` command.