### PR TITLE
fix: Fixed bug caused by trailing dash in URL

### DIFF
--- a/cli/src/main/scala/com/codacy/analysis/cli/command/AnalyseCommand.scala
+++ b/cli/src/main/scala/com/codacy/analysis/cli/command/AnalyseCommand.scala
@@ -41,6 +41,7 @@ object AnalyseCommand {
         .apiBaseUrlArgument(analyze.api.codacyApiBaseUrl)
         .orElse(environment.apiBaseUrlEnvironmentVariable())
         .getOrElse("https://api.codacy.com")
+        .stripSuffix("/") // a trailing slash breaks the tools fetching mechanism
 
     val codacyClientOpt: Option[CodacyClient] =
       Credentials.get(environment, analyze.api, apiUrl).map(CodacyClient.apply)

--- a/toolRepository-plugins/src/main/scala/com/codacy/toolRepository/plugins/ToolRepositoryPlugins.scala
+++ b/toolRepository-plugins/src/main/scala/com/codacy/toolRepository/plugins/ToolRepositoryPlugins.scala
@@ -26,7 +26,7 @@ class ToolRepositoryPlugins() extends ToolRepository {
         Some(tool.sourceCodeUrl),
         tool.prefix,
         tool.needsCompilation,
-        hasConfigFile = false,
+        hasConfigFile = tool.hasConfigFile,
         tool.configFilename.to[Set],
         tool.isClientSide,
         tool.hasUIConfiguration)


### PR DESCRIPTION
If a URL is used with a trailing dash,
the CLI will fail because it cannot fetch the tools' information.
This commit will fix that.