### PR TITLE
fix: Remove references to Account API Token CY-3474

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,24 +252,6 @@ codacy-analysis-cli analyze \
 
 > In alternative to setting `--project-token` you can define CODACY_PROJECT_TOKEN in the environment.
 
-#### API Token
-
-You can find the project token in:
-* `Account -> Access Management`
-
-The username and project name can be retrieved from the URL in Codacy.
-
-```sh
-codacy-analysis-cli analyze \
-  --api-token <PROJECT-TOKEN> \
-  --username <USERNAME> \
-  --project <PROJECT-NAME> \
-  --tool <TOOL-SHORT-NAME> \
-  --directory <SOURCE-CODE-PATH>
-```
-
-> In alternative to setting `--api-token` you can define CODACY_API_TOKEN in the environment.
-
 ## Build
 
 ### Compile

--- a/cli/src/main/scala/com/codacy/analysis/cli/command/CLIApp.scala
+++ b/cli/src/main/scala/com/codacy/analysis/cli/command/CLIApp.scala
@@ -106,11 +106,11 @@ sealed trait CommandOptions {
 
 final case class APIOptions(@ValueDescription("The project token.")
                             projectToken: Option[String] = Option.empty,
-                            @ValueDescription("The api token.")
+                            @ValueDescription("The api token.") @Hidden
                             apiToken: Option[String] = Option.empty,
-                            @ValueDescription("The username.")
+                            @ValueDescription("The username.") @Hidden
                             username: Option[UserName] = Option.empty,
-                            @ValueDescription("The project name.")
+                            @ValueDescription("The project name.") @Hidden
                             project: Option[ProjectName] = Option.empty,
                             @ValueDescription("The codacy api base url.")
                             codacyApiBaseUrl: Option[String] = Some("https://api.codacy.com"))


### PR DESCRIPTION
This pull request removes references to the Account API Token from the documentation and CLI help output, since using the Account API Token only works for repositories belonging to legacy organizations and not for synced organizations.

These changes are similar to the ones on the Codacy Coverage Reporter: https://github.com/codacy/codacy-coverage-reporter/pull/256

See [CY-3474](https://codacy.atlassian.net/browse/CY-3474) for more details.