### PR TITLE
clean: Don't push 'stable' docker image for pull requests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,6 +229,10 @@ workflows:
           type: approval
           requires:
             - publish_docker_locally
+          filters:
+            branches:
+              only:
+                - master
       - codacy/shell:
           name: publish_dockerhub_stable
           context: CodacyDocker


### PR DESCRIPTION
Prevents noobs like me from doing the wrong thing