### PR TITLE
fix: Map folder for tools cache

### DIFF
--- a/core/src/test/scala/com/codacy/analysis/core/storage/FileDataStorageSpec.scala
+++ b/core/src/test/scala/com/codacy/analysis/core/storage/FileDataStorageSpec.scala
@@ -12,7 +12,7 @@ class FileDataStorageSpec extends Specification with NoLanguageFeatures with Moc
 
   case class Test(name: String)
 
-  class StorageTest() extends FileDataStorage[Test]("") {
+  class StorageTest() extends FileDataStorage[Test](File.currentWorkingDirectory, "") {
     override implicit val encoder: Encoder[Test] = deriveEncoder
     override implicit val decoder: Decoder[Test] = deriveDecoder
 

--- a/toolRepository-remote/src/main/scala/com/codacy/toolRepository/remote/storage/PatternSpecDataStorage.scala
+++ b/toolRepository-remote/src/main/scala/com/codacy/toolRepository/remote/storage/PatternSpecDataStorage.scala
@@ -3,9 +3,10 @@ package com.codacy.toolRepository.remote.storage
 import com.codacy.analysis.core.model.PatternSpec
 import com.codacy.analysis.core.storage.FileDataStorage
 import io.circe.{Decoder, Encoder}
+import better.files.File
 
-case class PatternSpecDataStorage(override val storageFilename: String)
-    extends FileDataStorage[PatternSpec](storageFilename) {
+case class PatternSpecDataStorage(override val currentWorkingDirectory: File, override val storageFilename: String)
+    extends FileDataStorage[PatternSpec](currentWorkingDirectory, storageFilename) {
 
   override implicit val encoder: Encoder[PatternSpec] =
     ToolPatternsSpecsEncoders.toolPatternEncoder

--- a/toolRepository-remote/src/main/scala/com/codacy/toolRepository/remote/storage/ToolSpecDataStorage.scala
+++ b/toolRepository-remote/src/main/scala/com/codacy/toolRepository/remote/storage/ToolSpecDataStorage.scala
@@ -3,9 +3,11 @@ package com.codacy.toolRepository.remote.storage
 import com.codacy.analysis.core.model.ToolSpec
 import com.codacy.analysis.core.storage.FileDataStorage
 import io.circe.{Decoder, Encoder}
+import better.files.File
 
-case class ToolSpecDataStorage(override val storageFilename: String = "tools")
-    extends FileDataStorage[ToolSpec](storageFilename) {
+case class ToolSpecDataStorage(override val currentWorkingDirectory: File,
+                               override val storageFilename: String = "tools")
+    extends FileDataStorage[ToolSpec](currentWorkingDirectory, storageFilename) {
 
   override implicit val encoder: Encoder[ToolSpec] =
     ToolPatternsSpecsEncoders.toolEncoder

--- a/toolRepository-remote/src/test/scala/com/codacy/toolRespository/remote/ToolRepositoryRemoteSpec.scala
+++ b/toolRepository-remote/src/test/scala/com/codacy/toolRespository/remote/ToolRepositoryRemoteSpec.scala
@@ -3,6 +3,7 @@ package com.codacy.toolRespository.remote
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.{HttpHeader, HttpResponse}
 import akka.stream.ActorMaterializer
+import better.files.File
 import cats.data.EitherT
 import com.codacy.analysis.clientapi.definitions._
 import com.codacy.analysis.clientapi.tools.{ListPatternsResponse, ListToolsResponse, ToolsClient}
@@ -92,29 +93,31 @@ class ToolRepositoryRemoteSpec extends Specification with Mockito with EitherMat
   private val patternA: Pattern = getPattern("internalId - A")
   private val patternB: Pattern = getPattern("internalId - B")
 
-  val mockToolsDataEmptyStorage: ToolSpecDataStorage = new ToolSpecDataStorage {
+  val mockToolsDataEmptyStorage: ToolSpecDataStorage = new ToolSpecDataStorage(File.currentWorkingDirectory) {
     override def save(tools: Seq[ToolSpec]): Boolean = true
 
     override def get(): Option[Seq[ToolSpec]] = None
   }
 
-  val mockToolsDataWithStorage: ToolSpecDataStorage = new ToolSpecDataStorage {
+  val mockToolsDataWithStorage: ToolSpecDataStorage = new ToolSpecDataStorage(File.currentWorkingDirectory) {
     override def save(tools: Seq[ToolSpec]): Boolean = true
 
     override def get(): Option[Seq[ToolSpec]] = Some(Seq(toolSpec(toolA.uuid)))
   }
 
-  val mockPatternDataEmptyStorage: PatternSpecDataStorage = new PatternSpecDataStorage(toolA.uuid) {
-    override def save(tools: Seq[PatternSpec]): Boolean = true
+  val mockPatternDataEmptyStorage: PatternSpecDataStorage =
+    new PatternSpecDataStorage(File.currentWorkingDirectory, toolA.uuid) {
+      override def save(tools: Seq[PatternSpec]): Boolean = true
 
-    override def get(): Option[Seq[PatternSpec]] = None
-  }
+      override def get(): Option[Seq[PatternSpec]] = None
+    }
 
-  val mockPatternDataWithStorage: PatternSpecDataStorage = new PatternSpecDataStorage(toolA.uuid) {
-    override def save(tools: Seq[PatternSpec]): Boolean = true
+  val mockPatternDataWithStorage: PatternSpecDataStorage =
+    new PatternSpecDataStorage(File.currentWorkingDirectory, toolA.uuid) {
+      override def save(tools: Seq[PatternSpec]): Boolean = true
 
-    override def get(): Option[Seq[PatternSpec]] = Some(Seq(patternSpec(patternA.id)))
-  }
+      override def get(): Option[Seq[PatternSpec]] = Some(Seq(patternSpec(patternA.id)))
+    }
 
   def eitherListToolsResponse(
     listToolsResponse: ListToolsResponse): EitherT[Future, Either[Throwable, HttpResponse], ListToolsResponse] = {


### PR DESCRIPTION
@codacy/toss I noticed that the cache was not working when running the CLI. can you give some feedback on how to proceed?

Some issues:
1. Tools remote call was not being cached (is this intentional because we don't have a way to invalidate it?)
2. The cache folder was reading the OS and user of the container - always Linux and root
3. The cache folder was not mounting the user folder to the container