### PR TITLE
fix: Make `--parallel` run effectively in parallel CY-4739 :breaking:

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,9 @@ sbt codacyCoverage
 
 ## Breaking Changes
 
-- 4.0.0 - Rename `analyse` command to `analyze`. This is a breaking change if you are running the CLI by using the
+- `7.0.0`: Fix `--parallel` that wasn't making the tools run actually in parallel. To restore the previous behaviour use `--parallel 1`
+
+- `4.0.0`: Rename `analyse` command to `analyze`. This is a breaking change if you are running the CLI by using the
   [jar](#java) or [`sbt`](#local), but not if you are using the [provided script](#script).
 
 ## What is Codacy

--- a/core/src/main/scala/com/codacy/analysis/core/utils/SetOps.scala
+++ b/core/src/main/scala/com/codacy/analysis/core/utils/SetOps.scala
@@ -9,8 +9,11 @@ object SetOps {
 
   def mapInParallel[A, B](set: Set[A], nrParallel: Option[Int] = Option.empty[Int])(f: A => B): Seq[B] = {
     val setPar: ParSet[A] = set.par
-    setPar.tasksupport = new ForkJoinTaskSupport(new ForkJoinPool(nrParallel.getOrElse(2)))
-    setPar.map(f)(collection.breakOut)
+    val forkJoinPool = new ForkJoinPool(nrParallel.getOrElse(2))
+    setPar.tasksupport = new ForkJoinTaskSupport(forkJoinPool)
+    val result = setPar.map(f)
+    forkJoinPool.shutdown()
+    result.seq.toSeq
   }
 
 }

--- a/core/src/test/scala/com.codacy.analysis.core/utils/SetOpsSpec.scala
+++ b/core/src/test/scala/com.codacy.analysis.core/utils/SetOpsSpec.scala
@@ -6,15 +6,19 @@ class SetOpsSpec extends Specification {
 
   "SetOps.mapInParallel" should {
     "actually run in parallel" in {
+      val sleepMillis = 100L
+      val parallelism = 20
+
       val initialTime = System.currentTimeMillis()
-      SetOps.mapInParallel(1.to(1000).toSet, Some(1000)) { _ =>
-        Thread.sleep(10)
+      SetOps.mapInParallel(1.to(parallelism).toSet, Some(parallelism)) { _ =>
+        Thread.sleep(sleepMillis)
       }
       val finalTime = System.currentTimeMillis()
 
-      val elapsedSeconds = (finalTime - initialTime) / 1000
+      val elapsedMillis = finalTime - initialTime
+      val expectedMaxMillis = (sleepMillis * parallelism * 0.95).toLong
 
-      elapsedSeconds should beLessThan(9L)
+      elapsedMillis should beLessThan(expectedMaxMillis)
     }
   }
 }

--- a/core/src/test/scala/com.codacy.analysis.core/utils/SetOpsSpec.scala
+++ b/core/src/test/scala/com.codacy.analysis.core/utils/SetOpsSpec.scala
@@ -1,0 +1,20 @@
+package com.codacy.analysis.core.utils
+
+import org.specs2.mutable.Specification
+
+class SetOpsSpec extends Specification {
+
+  "SetOps.mapInParallel" should {
+    "actually run in parallel" in {
+      val initialTime = System.currentTimeMillis()
+      SetOps.mapInParallel(1.to(1000).toSet, Some(1000)) { _ =>
+        Thread.sleep(10)
+      }
+      val finalTime = System.currentTimeMillis()
+
+      val elapsedSeconds = (finalTime - initialTime) / 1000
+
+      elapsedSeconds should beLessThan(9L)
+    }
+  }
+}

--- a/core/src/test/scala/com.codacy.analysis.core/utils/SetOpsSpec.scala
+++ b/core/src/test/scala/com.codacy.analysis.core/utils/SetOpsSpec.scala
@@ -6,19 +6,16 @@ class SetOpsSpec extends Specification {
 
   "SetOps.mapInParallel" should {
     "actually run in parallel" in {
-      val sleepMillis = 100L
-      val parallelism = 20
+      val parallelism = 10
 
-      val initialTime = System.currentTimeMillis()
-      SetOps.mapInParallel(1.to(parallelism).toSet, Some(parallelism)) { _ =>
-        Thread.sleep(sleepMillis)
+      val threadsIds = SetOps.mapInParallel(1.to(parallelism).toSet, Some(parallelism)) { _ =>
+        // If the function terminates too fast the thread pool reuses the same threads
+        Thread.sleep(100)
+
+        Thread.currentThread().getId()
       }
-      val finalTime = System.currentTimeMillis()
 
-      val elapsedMillis = finalTime - initialTime
-      val expectedMaxMillis = (sleepMillis * parallelism * 0.95).toLong
-
-      elapsedMillis should beLessThan(expectedMaxMillis)
+      threadsIds.distinct should haveSize(parallelism)
     }
   }
 }


### PR DESCRIPTION
Fixes #406