### PR TITLE
fix: Use latest orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@5.2.3
+  codacy: codacy/base@5.4.1
   slack: circleci/slack@3.3.0
 
 references:
@@ -144,18 +144,21 @@ workflows:
           write_sbt_version: true
       - codacy/sbt:
           name: compile
+          install_sbt_version: 1.3.12
           cmd: sbt coverage +test:compile
           persist_to_workspace: true
           requires:
             - codacy/checkout_and_version
       - codacy/sbt:
           name: lint
+          install_sbt_version: 1.3.12
           cmd: |
             sbt "scalafmtCheckAll;scalafmtSbtCheck;scapegoat;scalafixEnable;scalafix --test"
           requires:
             - compile
       - codacy/sbt:
           name: test
+          install_sbt_version: 1.3.12
           cmd: |
             git config --global user.email "team@codacy.com"
             git config --global user.name "Codacy Team"
@@ -165,6 +168,7 @@ workflows:
             - compile
       - codacy/sbt:
           name: publish_docker_locally
+          install_sbt_version: 1.3.12
           cmd: |
             sbt "set codacyAnalysisCli / version := \"dev-snapshot\";
                  codacyAnalysisCli/docker:publishLocal"
@@ -187,6 +191,7 @@ workflows:
       #       - maven_dependencies
       - codacy/sbt:
           name: publish_lib
+          install_sbt_version: 1.3.12
           context: CodacyAWS
           cmd: |
             sbt "retrieveGPGKeys;
@@ -211,6 +216,7 @@ workflows:
                 - master
       - codacy/sbt:
           name: build_cli_jar
+          install_sbt_version: 1.3.12
           persist_to_workspace: true
           cmd: |
             sbt "set codacyAnalysisCli / version := \"$(cat .version)\";


### PR DESCRIPTION
The latest orb fixes a regression issues on the publish docker step, which led to the need to downgrade the orb version in this workflow.