### PR TITLE
doc: Update help string for --skip-ssl-verification

### DIFF
--- a/cli/src/main/scala/com/codacy/analysis/cli/command/CLIApp.scala
+++ b/cli/src/main/scala/com/codacy/analysis/cli/command/CLIApp.scala
@@ -146,7 +146,8 @@ final case class Analyze(
   skipCommitUuidValidation: Int @@ Counter = Tag.of(0),
   @ExtraName("u") @ValueDescription("If the results should be uploaded to the API")
   upload: Int @@ Counter = Tag.of(0),
-  @ExtraName("i") @ValueDescription("[default: false] - Skip the SSL certificate verification when communicating with the Codacy API")
+  @ExtraName("i") @ValueDescription(
+    "[default: false] - Skip the SSL certificate verification when communicating with the Codacy API")
   skipSslVerification: Int @@ Counter = Tag.of(0),
   @ExtraName("p") @ValueDescription("The number of tools to run in parallel")
   parallel: Option[Int] = Option.empty,

--- a/cli/src/main/scala/com/codacy/analysis/cli/command/CLIApp.scala
+++ b/cli/src/main/scala/com/codacy/analysis/cli/command/CLIApp.scala
@@ -146,7 +146,7 @@ final case class Analyze(
   skipCommitUuidValidation: Int @@ Counter = Tag.of(0),
   @ExtraName("u") @ValueDescription("If the results should be uploaded to the API")
   upload: Int @@ Counter = Tag.of(0),
-  @ExtraName("i") @ValueDescription("[default: false] - Skips ssl verification when comunicating with Codacy API")
+  @ExtraName("i") @ValueDescription("[default: false] - Skip the SSL certificate verification when communicating with the Codacy API")
   skipSslVerification: Int @@ Counter = Tag.of(0),
   @ExtraName("p") @ValueDescription("The number of tools to run in parallel")
   parallel: Option[Int] = Option.empty,


### PR DESCRIPTION
This occurrence of the help string wasn't updated in @heliocodacy's original pull request (https://github.com/codacy/codacy-analysis-cli/pull/413).