### PR TITLE
Feature/ignore uncommitted changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Found [Clone] 7 duplicated lines with 10 tokens:
     * `--format` [default: text] - Change the output format (e.g. json)
     * `--commit-uuid` [default: latest commit of current git branch] - Set the commit UUID that will receive the results on Codacy
     * `--skip-commit-uuid-validation` [default: false] - Force using a commit UUID even if it doesn't belong to the current git branch.
+    * `--skip-uncommitted-files-check` [default: false] - Skip check for uncommitted files in the analysis directory
     * `--upload` [default: false] - Request to push results to Codacy
     * `--skip-ssl-verification` [default: false] - Skip the SSL certificate verification when communicating with the Codacy API
     * `--parallel` [default: 2] - Number of tools to run in parallel

--- a/cli/src/main/scala/com/codacy/analysis/cli/command/AnalyseCommand.scala
+++ b/cli/src/main/scala/com/codacy/analysis/cli/command/AnalyseCommand.scala
@@ -120,19 +120,19 @@ class AnalyseCommand(analyze: Analyze,
         },
         { repository =>
           for {
-            _ <- validateNoUncommitedChanges(repository, configuration.upload.upload)
+            _ <- validateNoUncommitedChanges(repository, configuration.upload.upload, analyze.skipUncommittedFilesCheckValue)
             _ <- validateGitCommitUuid(repository, analyze.commitUuid, analyze.skipCommitUuidValidationValue)
           } yield ()
         })
   }
 
-  private def validateNoUncommitedChanges(repository: Repository, upload: Boolean): Either[CLIError, Unit] = {
+  private def validateNoUncommitedChanges(repository: Repository, upload: Boolean, skipUncommittedFilesCheck: Boolean): Either[CLIError, Unit] = {
     repository.uncommitedFiles.fold(
       { _ =>
         Right(())
       },
       { uncommitedFiles =>
-        if (uncommitedFiles.nonEmpty) {
+        if (!skipUncommittedFilesCheck && uncommitedFiles.nonEmpty) {
           val error: CLIError = CLIError.UncommitedChanges(uncommitedFiles)
           if (upload) {
             logger.error(error.message)

--- a/cli/src/main/scala/com/codacy/analysis/cli/command/AnalyseCommand.scala
+++ b/cli/src/main/scala/com/codacy/analysis/cli/command/AnalyseCommand.scala
@@ -120,13 +120,18 @@ class AnalyseCommand(analyze: Analyze,
         },
         { repository =>
           for {
-            _ <- validateNoUncommitedChanges(repository, configuration.upload.upload, analyze.skipUncommittedFilesCheckValue)
+            _ <- validateNoUncommitedChanges(
+              repository,
+              configuration.upload.upload,
+              analyze.skipUncommittedFilesCheckValue)
             _ <- validateGitCommitUuid(repository, analyze.commitUuid, analyze.skipCommitUuidValidationValue)
           } yield ()
         })
   }
 
-  private def validateNoUncommitedChanges(repository: Repository, upload: Boolean, skipUncommittedFilesCheck: Boolean): Either[CLIError, Unit] = {
+  private def validateNoUncommitedChanges(repository: Repository,
+                                          upload: Boolean,
+                                          skipUncommittedFilesCheck: Boolean): Either[CLIError, Unit] = {
     repository.uncommitedFiles.fold(
       { _ =>
         Right(())

--- a/cli/src/main/scala/com/codacy/analysis/cli/command/CLIApp.scala
+++ b/cli/src/main/scala/com/codacy/analysis/cli/command/CLIApp.scala
@@ -144,6 +144,8 @@ final case class Analyze(
   commitUuid: Option[Commit.Uuid] = Option.empty,
   @ExtraName("s") @ValueDescription("[default: false] - Force using a commit UUID")
   skipCommitUuidValidation: Int @@ Counter = Tag.of(0),
+  @ExtraName("g") @ValueDescription("[default: false] - Skip the check for uncommitted files in the analysis directory")
+  skipUncommittedFilesCheck: Int @@ Counter = Tag.of(0),
   @ExtraName("u") @ValueDescription("If the results should be uploaded to the API")
   upload: Int @@ Counter = Tag.of(0),
   @ExtraName("i") @ValueDescription(
@@ -178,6 +180,7 @@ final case class Analyze(
   val forceFilePermissionsValue: Boolean = forceFilePermissions.## > 0
   val ghCodeScanningCompatValue: Boolean = ghCodeScanningCompat.## > 0
   val skipCommitUuidValidationValue: Boolean = skipCommitUuidValidation.## > 0
+  val skipUncommittedFilesCheckValue: Boolean = skipUncommittedFilesCheck.## > 0
   val skipSslVerificationValue: Boolean = skipSslVerification.## > 0
 
 }


### PR DESCRIPTION
Adding this flag for a prospect. This is blocking their POC. The intent is to allow a client to ignore the uncommitted changes error that occurs when files are added to the repo directory during a build. 

The flag is false by default so the client will need to make the conscious choice to ignore this safety check.