### PR TITLE
feature: support issues-only analysis and log upload parsing failures CY-5727

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Found [Clone] 7 duplicated lines with 10 tokens:
 * `analyze` - Run a Codacy analysis over a directory/files
     * `--help` - Displays all the configuration options, their meaning and possible values.
     * `--verbose` - Run the tool with verbose output
-    * `--tool` - [Choose the tool](https://docs.codacy.com/repositories-configure/codacy-configuration-file/#which-tools-can-be-configured-and-which-name-should-i-use) to analyze the code (e.g. brakeman)
+    * `--tool` - [Choose the tool](https://docs.codacy.com/repositories-configure/codacy-configuration-file/#which-tools-can-be-configured-and-which-name-should-i-use) to analyze the code (e.g. brakeman), or "metrics", "duplication", "issues" to run only a specific tool category
     * `--directory` - Choose the directory to be analysed
     * `--codacy-api-base-url` or env.`CODACY_API_BASE_URL` - Change the Codacy installation API URL to retrieve the configuration (e.g. Enterprise installation)
     * `--output` - Send the output results to a file

--- a/cli/src/main/scala/com/codacy/analysis/cli/analysis/ToolSelector.scala
+++ b/cli/src/main/scala/com/codacy/analysis/cli/analysis/ToolSelector.scala
@@ -34,6 +34,10 @@ class ToolSelector(toolRepository: ToolRepository) {
       case Some("duplication") =>
         duplicationToolsEither.map(_.map(_.to[ITool]))
 
+      case Some("issues") =>
+        val toolsEither = tools(None, configuration, languages)
+        toolsEither.map(_.map(_.to[ITool]))
+
       case Some(_) =>
         val toolsEither = tools(toolInput, configuration, languages)
         toolsEither.map(_.map(_.to[ITool]))


### PR DESCRIPTION
Adds capability to run only issues analysis.

I was already possible for duplication and metrics, just extending it to fit the use case of some customers (and to mitigate our limitation of payload size for duplication and metrics)