### PR TITLE
Fix request metrics analysis on empty files (IO-47)

### DIFF
--- a/cli/src/main/scala/com/codacy/analysis/cli/analysis/ToolSelector.scala
+++ b/cli/src/main/scala/com/codacy/analysis/cli/analysis/ToolSelector.scala
@@ -16,9 +16,11 @@ class ToolSelector(toolRepository: ToolRepository) {
   def allTools(toolInputOpt: Option[String],
                configuration: CLIConfiguration.Tool,
                languages: Set[Language]): Either[CLIError, Set[ITool]] = {
-    def duplicationToolsEither =
+
+    def duplicationToolsEither: Either[CLIError.CouldNotGetTools, Set[DuplicationTool]] =
       duplicationToolCollector.fromLanguages(languages).left.map(e => CLIError.CouldNotGetTools(e.message))
-    def metricsToolsEither =
+
+    def metricsToolsEither: Either[CLIError.CouldNotGetTools, Set[MetricsTool]] =
       metricsToolCollector.fromLanguages(languages).left.map(e => CLIError.CouldNotGetTools(e.message))
 
     toolInputOpt match {
@@ -55,6 +57,7 @@ class ToolSelector(toolRepository: ToolRepository) {
           .map(_ => CLIError.NonExistentToolsFromRemoteConfiguration(toolUuids))
       }
     }
+
     def fromLocalConfig: Either[CLIError, Set[Tool]] = {
       toolCollector.fromLanguages(languages).left.map(CLIError.from)
     }

--- a/core/src/main/scala/com/codacy/analysis/core/analysis/Analyser.scala
+++ b/core/src/main/scala/com/codacy/analysis/core/analysis/Analyser.scala
@@ -21,7 +21,7 @@ trait Analyser {
 
   def metrics(metricsTool: MetricsTool,
               directory: File,
-              files: Option[Set[Path]],
+              files: Set[Path],
               tmpDirectory: Option[File],
               timeout: Option[Duration] = Option.empty[Duration],
               maxToolMemory: Option[String] = None): Try[Set[FileMetrics]]

--- a/core/src/main/scala/com/codacy/analysis/core/analysis/CodacyPluginsAnalyser.scala
+++ b/core/src/main/scala/com/codacy/analysis/core/analysis/CodacyPluginsAnalyser.scala
@@ -36,12 +36,12 @@ final class CodacyPluginsAnalyser() extends Analyser {
 
   override def metrics(metricsTool: MetricsTool,
                        directory: File,
-                       files: Option[Set[Path]],
+                       files: Set[Path],
                        tmpDirectory: Option[File],
                        timeout: Option[Duration] = Option.empty[Duration],
                        maxToolMemory: Option[String] = None): Try[Set[FileMetrics]] = {
 
-    val srcFiles = files.map(_.map(filePath => Source.File(filePath.toString)))
+    val srcFiles = files.map(filePath => Source.File(filePath.toString))
 
     val result = metricsTool.run(directory, srcFiles, tmpDirectory, timeout, maxToolMemory)
 

--- a/core/src/main/scala/com/codacy/analysis/core/files/FileCollector.scala
+++ b/core/src/main/scala/com/codacy/analysis/core/files/FileCollector.scala
@@ -55,7 +55,9 @@ trait FileCollector[T[_]] {
       Set[Set[Path] => Set[Path]](
         filterByGlobs(_, exclusionRules.excludePaths.byTool.getOrElse(tool.name, Set.empty)),
         filterByLanguage(tool.languageToRun, exclusionRules.allowedExtensionsByLanguage))
+
     val filteredFiles = filters.foldLeft(target.readableFiles) { case (fs, filter) => filter(fs) }
+
     target.copy(readableFiles = filteredFiles)
   }
 

--- a/core/src/test/scala/com.codacy.analysis.core/tools/MetricsToolSpec.scala
+++ b/core/src/test/scala/com.codacy.analysis.core/tools/MetricsToolSpec.scala
@@ -21,24 +21,6 @@ class MetricsToolSpec extends Specification with NoLanguageFeatures {
   val jsTestMetrics = FileMetrics(Paths.get("test.js"), None, Some(60), Some(0), None, None, Set())
 
   "MetricsTool" should {
-    "analyze metrics on a project" in {
-      val commitUuid = "625e19cd9be4898939a7c40dbeb2b17e40df9d54"
-      withClonedRepo("git@github.com:qamine-test/duplication-delta.git", commitUuid) { (_, directory) =>
-        val testProjectFileMetrics = List(jsTest2Metrics, jsTestMetrics)
-
-        val metricsTool = new MetricsTool(cloc, Languages.Javascript)
-
-        val result = metricsTool.run(directory, None)
-
-        result must beSuccessfulTry
-        result must beLike {
-          case Success(metricsResults) =>
-            metricsResults must haveSize(testProjectFileMetrics.size)
-            metricsResults must containTheSameElementsAs(testProjectFileMetrics)
-        }
-      }
-    }
-
     "analyze metrics on a project, ignoring a file" in {
       val commitUuid = "625e19cd9be4898939a7c40dbeb2b17e40df9d54"
       withClonedRepo("git@github.com:qamine-test/duplication-delta.git", commitUuid) { (_, directory) =>
@@ -46,7 +28,7 @@ class MetricsToolSpec extends Specification with NoLanguageFeatures {
 
         val metricsTool = new MetricsTool(cloc, Languages.Javascript)
 
-        val result = metricsTool.run(directory, Some(Set(Source.File("test.js"))))
+        val result = metricsTool.run(directory, Set(Source.File("test.js")))
 
         result must beSuccessfulTry
         result must beLike {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.1
+sbt.version=1.7.1


### PR DESCRIPTION
We shouldn't be calling metrics tool to run for a set of empty files.

The normal linters seem already protected. I've put the change in the most similar place mirroring what the linters also do.