### PR TITLE
Remove test-docker-socket CY-6629

### DIFF
--- a/bin/codacy-analysis-cli.sh
+++ b/bin/codacy-analysis-cli.sh
@@ -17,14 +17,6 @@ log_error() {
   exit 3
 }
 
-test_docker_socket() {
-  if [ ! -S /var/run/docker.sock ]; then
-    log_error "/var/run/docker.sock must exist as a Unix domain socket"
-  elif [ -n "${DOCKER_HOST}" ] && [ "${DOCKER_HOST}" != "unix:///var/run/docker.sock" ]; then
-    log_error "invalid DOCKER_HOST=${DOCKER_HOST}, must be unset or unix:///var/run/docker.sock"
-  fi
-}
-
 run() {
   local output_volume="";
   if [ -n "${OUTPUT_DIRECTORY}" ]; then


### PR DESCRIPTION
A customer is trying to understand why we need to test this. He says: "why do we need to test the socket file? Given the evolving nature of docker and K8s, the checking of socket file doesn’t seem applicable anymore."

More details in the ticket https://codacy.atlassian.net/browse/CY-6629 @machadoit @pedrocodacy @lolgab