### PR TITLE
doc: Improve description of --skip-docker-test TS-106

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Found [Clone] 7 duplicated lines with 10 tokens:
     * `--skip-uncommitted-files-check` [default: false] - Skip check for uncommitted files in the analysis directory
     * `--upload` [default: false] - Request to push results to Codacy
     * `--upload-batch-size` [default: 50000] - Maximum number of results in each batch to upload to Codacy
-    * `--skip-docker-test` [default: false] - Skip the test_docker_socket().
+    * `--skip-docker-test` [default: false] - Skip testing if the default Unix socket for the Docker daemon exists
     * `--skip-ssl-verification` [default: false] - Skip the SSL certificate verification when communicating with the Codacy API
     * `--parallel` [default: 2] - Number of tools to run in parallel
     * `--max-allowed-issues` [default: 0] - Maximum number of issues allowed for the analysis to succeed


### PR DESCRIPTION
Improves the description for the new flag `--skip-docker-test` introduced in #462 to let users know what it does since the previous description mentioned the name of our internal function instead.