### PR TITLE
bump: Bump codacy-plugins-api to v7.2.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,7 +30,7 @@ object Dependencies {
   val codacyPlugins =
     Seq("codacy-plugins", "codacy-plugins-runner-binary").map("com.codacy" %% _ % codacyPluginsVersion)
 
-  lazy val pluginsApi = "com.codacy" %% "codacy-plugins-api" % "5.3.1"
+  lazy val pluginsApi = "com.codacy" %% "codacy-plugins-api" % "7.2.1"
 
   lazy val pprint = "com.lihaoyi" %% "pprint" % "0.5.7"
 


### PR DESCRIPTION
Bumping `codacy-plugins-api` to its latest version, v7.2.1.