### PR TITLE
feat: pass JAVA_TOOL_OPTIONS to docker container

### DIFF
--- a/bin/codacy-analysis-cli.sh
+++ b/bin/codacy-analysis-cli.sh
@@ -39,6 +39,7 @@ run() {
     --env CODACY_PROJECT_TOKEN="$CODACY_PROJECT_TOKEN" \
     --env CODACY_API_TOKEN="$CODACY_API_TOKEN" \
     --env CODACY_API_BASE_URL="$CODACY_API_BASE_URL" \
+    --env JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS" \
     --volume /var/run/docker.sock:/var/run/docker.sock \
     --volume "$CODACY_CODE":"$CODACY_CODE" \
     ${output_volume} \


### PR DESCRIPTION
This change passes the JAVA_TOOL_OPTIONS to the docker container running the analysis. Doing this allows to setup a custom trust store that can successfully create SSL connections to a codacy-proxy. Using a codacy-proxy allows to transparently authorize upload of results from a CI/CD system without storing Codacy tokens.